### PR TITLE
Remove extra KEYWORD_TOKENTYPE from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -42,7 +42,7 @@ stopLED	KEYWORD2
 stringFromInt	KEYWORD2
 ThreeStage	KEYWORD2
 throttlePin	KEYWORD2
-Timed	KEYWORD2	KEYWORD2
+Timed	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Timed keyword definition had an extra KEYWORD2 in the REFERENCE_LINK field. The third field of keywords.txt is used to provide Arduino Language/Libraries Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format